### PR TITLE
Use selections in Convert command

### DIFF
--- a/src/commands/Convert.hpp
+++ b/src/commands/Convert.hpp
@@ -18,6 +18,7 @@ public:
         std::string output_format = "";
         std::string topology = "";
         std::string topology_format = "";
+        std::string selection = "";
         bool custom_cell = false;
         chemfiles::UnitCell cell;
         bool guess_bonds = false;
@@ -25,11 +26,12 @@ public:
         steps_range steps;
     };
 
-    Convert() {}
+    Convert(): selection_("all") {}
     int run(int argc, const char* argv[]) override;
     std::string description() const override;
 private:
     Options options_;
+    chemfiles::Selection selection_;
 };
 
 #endif

--- a/tests/convert.py
+++ b/tests/convert.py
@@ -28,6 +28,13 @@ H 1.497 5.859 1.682
 H 0.56 6.554 0.717
 """
 
+XYZ_SEL_CONTENT = """3
+Written by the chemfiles library
+O 0.417 8.303 11.737
+O 9.733 8.95 5.501
+O 1.486 6.471 0.946
+"""
+
 
 class isolate_files(object):
     '''
@@ -67,3 +74,9 @@ if __name__ == '__main__':
         assert(err == "")
         with open(filename + ".xyz") as fd:
             assert(fd.read() == XYZ_CONTENT)
+    with isolate_files(filename):
+        out, err = cfiles("convert", filename + ".pdb", filename + ".xyz","--selection", 'atoms: type O')
+        assert(out == "")
+        assert(err == "")
+        with open(filename + ".xyz") as fd:
+            assert(fd.read() == XYZ_SEL_CONTENT)


### PR DESCRIPTION
Fix #24 
I added a feature for defining a selection for the output in the Convert command. It could be either of size 1, 2, 3 or 4.